### PR TITLE
계획 상세 페이지 css 및 formatTime 함수 수정

### DIFF
--- a/src/components/DayPlan/index.tsx
+++ b/src/components/DayPlan/index.tsx
@@ -1,5 +1,5 @@
 // 라이브러리
-import React, { useState } from 'react';
+import React from 'react';
 
 // 파일
 import * as _ from './style';

--- a/src/components/DayPlan/style.ts
+++ b/src/components/DayPlan/style.ts
@@ -9,7 +9,7 @@ export const DayPlan_Layout = styled.div`
 export const DayPlan_Times = styled.div`
   display: flex;
   flex-direction: column;
-  padding-left: 10px;
+  padding-left: 20px;
   align-items: center;
   width: max-content;
 `;
@@ -28,16 +28,15 @@ export const DayPlan_Date = styled.div`
 
 export const DayPlan_Content = styled.div`
   display: flex;
-  padding-top: 20px;
+  padding: 20px 0 0 10px;
   justify-content: space-between;
 `;
 
 export const DayPlan_Left = styled.div`
   display: flex;
-  width: 90px;
+  width: 94px;
   align-self: flex-start;
   align-items: center;
-  gap: 10px;
   justify-content: space-between;
 `;
 
@@ -65,7 +64,7 @@ export const DayPlan_Right = styled.div`
   position: relative;
   display: flex;
   flex-direction: column;
-  width: 70%;
+  width: 68%;
   padding: 13px 16px;
   margin-top: 12px;
   border-radius: 15px;
@@ -75,7 +74,7 @@ export const DayPlan_Right = styled.div`
 
 export const DayPlan_Activity = styled.p`
   color: ${theme.gray.black};
-  font-size: 18px;
+  font-size: 16px;
   font-weight: 500;
 `;
 

--- a/src/components/Header/style.ts
+++ b/src/components/Header/style.ts
@@ -11,6 +11,7 @@ export const Header_Container = styled.div<{ isOnChatting?: boolean }>`
   border-bottom: 1px solid
     ${(props) => (props.isOnChatting ? theme.gray[1] : 'none ')};
   flex-shrink: 0;
+  position: relative;
 `;
 
 export const Header_BackIcon = styled.div`
@@ -23,11 +24,17 @@ export const Header_ProgressBar = styled.div`
   flex-direction: column;
   align-items: center;
   justify-content: center;
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
 `;
 
 export const Header_Title = styled.div`
   font-weight: 600;
   font-size: 17px;
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
 `;
 
 export const Header_Button = styled.div<{ ButtonColor?: string }>`

--- a/src/data/TripSchedule.ts
+++ b/src/data/TripSchedule.ts
@@ -1,7 +1,7 @@
 export const TripSchedule = [
   [
     {
-      time: '10:00',
+      time: '10:59',
       activity: '서면 문화를 즐기기',
       location: '부산 부산진구 서면로68번길 9',
       recommendation:

--- a/src/lib/utils/formatTime.ts
+++ b/src/lib/utils/formatTime.ts
@@ -2,5 +2,5 @@ export const formatTime = (time: string): string => {
   const [hours, minutes] = time.split(':').map(Number);
   const period = hours < 12 ? '오전' : '오후';
   const formattedHours = hours % 12 === 0 ? 12 : hours % 12;
-  return `${period} ${formattedHours}시 ${minutes > 0 ? `${minutes}분` : ''}`;
+  return `${period} ${formattedHours}:${minutes > 0 ? `${minutes}` : '00'}`;
 };

--- a/src/pages/plan/info/index.tsx
+++ b/src/pages/plan/info/index.tsx
@@ -59,7 +59,7 @@ const Info = () => {
           <_.Info_GoToMap>지도로 보기</_.Info_GoToMap>
           <_.Info_DetailList>
             {TripSchedule.map((day, index) => {
-              const lineHeight = 75 + 115 * (day.length - 1);
+              const lineHeight = 75 + 110 * (day.length - 1);
               return (
                 <_.Info_Date key={index}>
                   <_.Info_Line height={lineHeight} />

--- a/src/pages/plan/info/style.ts
+++ b/src/pages/plan/info/style.ts
@@ -60,7 +60,7 @@ export const Info_Nav = styled.div`
 
 export const Info_Duration = styled.p`
   color: ${theme.gray.black};
-  font-size: 18px;
+  font-size: 16px;
   font-weight: 500;
 `;
 
@@ -75,7 +75,8 @@ export const Info_Schedule = styled.div`
 `;
 
 export const Info_DetailList = styled.div`
-  padding: 0 0 20px 17px;
+  /* padding: 0 0 20px 17px; */
+  padding-bottom: 20px;
   width: 100%;
   display: flex;
   flex-direction: column;
@@ -85,7 +86,7 @@ export const Info_DetailList = styled.div`
 
 export const Info_Line = styled.div<{ height?: number }>`
   position: absolute;
-  left: 79px;
+  left: 94px;
   width: 2px;
   z-index: -1;
   height: ${(props) => props.height}px;


### PR DESCRIPTION
계획 상세 페이지 css 및 formatTime 함수 수정

### 📌 개요
계획 상세 페이지를 수정

#### 🔗 작업 내용
1. css 변경
2. formatTime 함수 return 값 수정

#### 🐳 반영 브랜치
- feat/plan/detail-> develop

#### 🕶️ 테스트 결과
<img width="195px" height="422px" alt="image" src="https://github.com/user-attachments/assets/a9c5c923-0b35-4ed5-81e8-251172ee1a12">

#### 🔅 기타